### PR TITLE
Adding set language at run time

### DIFF
--- a/speechInteraction/modules/googleSynthesis/app/conf/config.ini
+++ b/speechInteraction/modules/googleSynthesis/app/conf/config.ini
@@ -1,3 +1,7 @@
 name              googleSynthesis
-language_code     en-US
-sample_rate_hertz 16000
+language          en-US
+voice             en-US-Wavenet-D
+pitch             0.0
+speed             1.0
+languageCodes     en-US it-IT pt-PT fr-FR en-GB
+voiceCodes        en-US-Wavenet-A en-US-Wavenet-B en-US-Wavenet-C en-US-Wavenet-D en-US-Wavenet-E en-US-Wavenet-F en-US-Wavenet-G en-US-Wavenet-H en-US-Wavenet-I en-US-Wavenet-J fr-FR-Wavenet-A fr-FR-Wavenet-B fr-FR-Wavenet-C fr-FR-Wavenet-D en-GB-Wavenet-A en-GB-Wavenet-B en-GB-Wavenet-C en-GB-Wavenet-D pt-PT-Wavenet-A pt-PT-Wavenet-B pt-PT-Wavenet-C pt-PT-Wavenet-D it-IT-Wavenet-A it-IT-Wavenet-B it-IT-Wavenet-C it-IT-Wavenet-D

--- a/speechInteraction/modules/googleSynthesis/googleSynthesis.thrift
+++ b/speechInteraction/modules/googleSynthesis/googleSynthesis.thrift
@@ -24,4 +24,57 @@ service googleSynthesis_IDL
      */
     bool quit();
 
+    /**
+     * Say the phrase.
+     * @param string containing the phrase to synthesise
+     * @return true/false on success/failure
+     */
+    bool say(1:string phrase);
+
+    /**
+     * Set the language of the synthesiser. 
+     * example: setLanguage en-US en-US-Wavenet-A
+     * @param string containing the languageCode
+     * @param string containing the voiceCode
+     * @return true/false on success/failure
+     */
+    string setLanguage(1:string languageCode, 2:string voiceCode);
+
+    /**
+     * Set the pitch of the synthesiser.
+     * @param double containing the desired pitch for the synthesiser
+     * @return true/false on success/failure
+     */
+    bool setPitch(1:double pitch);
+
+    /**
+     * Set the speed of the synthesiser.
+     * @param double containing the desired speed for the synthesiser
+     * @return true/false on success/failure
+     */
+    bool setSpeed(1:double speed);
+
+    /**
+     * Get the language code of the synthesiser
+     * @return string containing the language code
+     */
+    string getLanguageCode();
+
+     /**
+     * Get the voice code of the synthesiser
+     * @return string containing the voice code
+     */
+    string getVoiceCode();
+
+     /**
+     * Get the pitch value of the synthesiser
+     * @return string containing the pitch value
+     */
+    double getPitch();
+
+    /**
+     * Get the speed value of the synthesiser
+     * @return string containing the speed code
+     */
+    double getSpeed();
 }


### PR DESCRIPTION
This PR adds the possibility to change the **language at run time.** 

The user is now able to modify the `language` through the  following `rpc command`. As one is also required to set a corresponding `voice` , we condensed the command to include both entries in one for ease of use. (Otherwise the user will have to send two distinct commands)

Example of the language switch:
```
setLanguage en-US en-US-Wavenet-D
```
by default, the language and voice codes currently supported are the following, but can be easily extended by adding the required entries in the `config.ini`

```
languageCodes     en-US it-IT pt-PT fr-FR en-GB
```
```
voiceCodes        en-US-Wavenet-A en-US-Wavenet-B en-US-Wavenet-C en-US-Wavenet-D en-US-Wavenet-E en-US-Wavenet-F en-US-Wavenet-G en-US-Wavenet-H en-US-Wavenet-I en-US-Wavenet-J fr-FR-Wavenet-A fr-FR-Wavenet-B fr-FR-Wavenet-C fr-FR-Wavenet-D en-GB-Wavenet-A en-GB-Wavenet-B en-GB-Wavenet-C en-GB-Wavenet-D pt-PT-Wavenet-A pt-PT-Wavenet-B pt-PT-Wavenet-C pt-PT-Wavenet-D it-IT-Wavenet-A it-IT-Wavenet-B it-IT-Wavenet-C it-IT-Wavenet-D
```

Here is a list of the possible interaction with the module 

```
setLanguage(1:string languageCode, 2:string voiceCode);
setPitch(1:double pitch);
setSpeed(1:double speed);
getLanguageCode();
getVoiceCode();
getPitch();
getSpeed();
```


cc @randaz81 @Bontempogianpaolo1