### PR TITLE
Adding setLanguage at runtime

### DIFF
--- a/speechInteraction/modules/googleDialog/app/conf/config.ini
+++ b/speechInteraction/modules/googleDialog/app/conf/config.ini
@@ -1,3 +1,4 @@
 name              googleDialog
 language_code     en-US
 sample_rate_hertz 16000
+languageCodes     en-US it-IT pt-PT fr-FR en-GB

--- a/speechInteraction/modules/googleDialog/googleDialog.thrift
+++ b/speechInteraction/modules/googleDialog/googleDialog.thrift
@@ -41,7 +41,7 @@ service googleDialog_IDL
      */
     bool resetDialog();
     
-    **
+    /**
      * Set the language of the synthesiser. 
      * example: setLanguage en-US
      * @param string containing the languageCode

--- a/speechInteraction/modules/googleDialog/googleDialog.thrift
+++ b/speechInteraction/modules/googleDialog/googleDialog.thrift
@@ -40,5 +40,19 @@ service googleDialog_IDL
      * Reset the conversation.
      */
     bool resetDialog();
+    
+    **
+     * Set the language of the synthesiser. 
+     * example: setLanguage en-US
+     * @param string containing the languageCode
+     * @return true/false on success/failure
+     */
+    bool setLanguage(1:string languageCode);
+
+    /**
+     * Get the language code of the synthesiser
+     * @return string containing the language code
+     */
+    string getLanguageCode();
 
 }

--- a/speechInteraction/modules/googleDialog/main.cpp
+++ b/speechInteraction/modules/googleDialog/main.cpp
@@ -205,6 +205,19 @@ public:
         return result;
    }
 
+   /********************************************************/
+    bool setLanguageCode(const std::string &languageCode)
+    {
+        language_code = languageCode;
+        return true;
+    }
+
+    /********************************************************/
+    std::string getLanguageCode()
+    {
+        return language_code;
+    }
+
     /********************************************************/
     bool start_acquisition()
     {
@@ -254,6 +267,7 @@ class Module : public yarp::os::RFModule, public googleDialog_IDL
     friend class                processing;
 
     bool                        closing;
+    std::vector<std::string>    allLanguageCodes;
 
     /********************************************************/
     bool attach(yarp::os::RpcServer &source)
@@ -274,6 +288,15 @@ public:
         std::string agent_name = rf.check("agent", yarp::os::Value("1"), "name of the agent").asString();
         std::string language_code = rf.check("language", yarp::os::Value("en-US"), "language of the dialogflow").asString();
         
+        if (rf.check("languageCodes", "Getting language codes"))
+        {
+            yarp::os::Bottle &grp=rf.findGroup("languageCodes");
+            int sz=grp.size()-1;
+
+            for (int i=0; i<sz; i++)
+                allLanguageCodes.push_back(grp.get(1+i).asString());
+        }
+
         yDebug() << "this is the project" << rf.check("project");
         yDebug() << "Module name" << moduleName;
         yDebug() << "agent name" << agent_name;
@@ -293,6 +316,33 @@ public:
         attach(rpcPort);
 
         return true;
+    }
+
+    /********************************************************/
+    bool setLanguage(const std::string& languageCode)
+    {
+        bool returnVal = false;
+        
+        std::string language;
+        
+        for (int i = 0; i < allLanguageCodes.size(); i++)
+        {
+            if (languageCode == allLanguageCodes[i])
+            {
+                language = languageCode;
+                processing->setLanguageCode(languageCode);
+                returnVal = true;
+                break;
+            }
+        }
+
+        return returnVal;
+    }
+
+    /********************************************************/
+    std::string getLanguageCode()
+    {
+        return processing->getLanguageCode();
     }
 
     /**********************************************************/

--- a/speechInteraction/modules/googleSpeech/app/conf/config.ini
+++ b/speechInteraction/modules/googleSpeech/app/conf/config.ini
@@ -1,3 +1,4 @@
 name              googleSpeech
 language_code     en-US
 sample_rate_hertz 16000
+languageCodes     en-US it-IT pt-PT fr-FR en-GB

--- a/speechInteraction/modules/googleSpeech/googleSpeech.thrift
+++ b/speechInteraction/modules/googleSpeech/googleSpeech.thrift
@@ -42,4 +42,18 @@ service googleSpeech_IDL
      * @return a double containing the processing time
      */
     i64 getProcessingTime();
+    
+        /**
+     * Set the language of the synthesiser. 
+     * example: setLanguage en-US
+     * @param string containing the languageCode
+     * @return true/false on success/failure
+     */
+    bool setLanguage(1:string languageCode);
+
+    /**
+     * Get the language code of the synthesiser
+     * @return string containing the language code
+     */
+    string getLanguageCode();
 }

--- a/speechInteraction/modules/googleSpeech/googleSpeech.thrift
+++ b/speechInteraction/modules/googleSpeech/googleSpeech.thrift
@@ -43,7 +43,7 @@ service googleSpeech_IDL
      */
     i64 getProcessingTime();
     
-        /**
+     /**
      * Set the language of the synthesiser. 
      * example: setLanguage en-US
      * @param string containing the languageCode

--- a/speechInteraction/modules/googleSpeech/main.cpp
+++ b/speechInteraction/modules/googleSpeech/main.cpp
@@ -283,6 +283,19 @@ public:
     }
 
     /********************************************************/
+    bool setLanguageCode(const std::string &languageCode)
+    {
+        language = languageCode;
+        return true;
+    }
+
+    /********************************************************/
+    std::string getLanguageCode()
+    {
+        return language;
+    }
+
+    /********************************************************/
     void setArguments(RecognitionConfig* config)
     {
         config->set_language_code(language.c_str());
@@ -348,6 +361,7 @@ class Module : public yarp::os::RFModule, public googleSpeech_IDL
 
     bool                        closing;
     bool                        uniqueSound;
+    std::vector<std::string>    allLanguageCodes;
 
     /********************************************************/
     bool attach(yarp::os::RpcServer &source)
@@ -372,6 +386,15 @@ public:
         if (rf.check("uniqueSound", "use a yarp::sig::Sound instead of a microphone"))
             uniqueSound = true;
         
+        if (rf.check("languageCodes", "Getting language codes"))
+        {
+            yarp::os::Bottle &grp=rf.findGroup("languageCodes");
+            int sz=grp.size()-1;
+
+            for (int i=0; i<sz; i++)
+                allLanguageCodes.push_back(grp.get(1+i).asString());
+        }
+
         setName(moduleName.c_str());
 
         rpcPort.open(("/"+getName("/rpc")).c_str());
@@ -391,6 +414,34 @@ public:
 
         return true;
     }
+
+    /********************************************************/
+    bool setLanguage(const std::string& languageCode)
+    {
+        bool returnVal = false;
+        
+        std::string language;
+        
+        for (int i = 0; i < allLanguageCodes.size(); i++)
+        {
+            if (languageCode == allLanguageCodes[i])
+            {
+                language = languageCode;
+                processing->setLanguageCode(languageCode);
+                returnVal = true;
+                break;
+            }
+        }
+
+        return returnVal;
+    }
+
+    /********************************************************/
+    std::string getLanguageCode()
+    {
+        return processing->getLanguageCode();
+    }
+
 
     /**********************************************************/
     bool close()


### PR DESCRIPTION
This PR adds the possibility to change the **language at run time.**  for both **googleSpeech** and **googleDialog**

The user is now able to modify the `language` through the  following `rpc command`. 

Example of the language switch:
```
setLanguage en-US
```
by default, the language and voice codes currently supported are the following, but can be easily extended by adding the required entries in the `config.ini`

```
languageCodes     en-US it-IT pt-PT fr-FR en-GB
```

Here is a list of the possible extra interaction with the module 

```
setLanguage(1:string languageCode);
getLanguageCode();
```
