### PR TITLE
Include string and vector in start-ask.h

### DIFF
--- a/speech-interpreters/start/ask/include/start-ask.h
+++ b/speech-interpreters/start/ask/include/start-ask.h
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string>
+#include <vector>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Network.h>


### PR DESCRIPTION
In `speech-interpreters/start/ask/src/start-ask.cpp`, `std::string` and `std::vector` are used, so it is better to directly include the relative headers to avoid failures due to changes in the included headers.

Fix https://github.com/robotology/speech/issues/43 .